### PR TITLE
Update to JavaFX 13

### DIFF
--- a/CommandLine/Modular/CLI/README.md
+++ b/CommandLine/Modular/CLI/README.md
@@ -1,9 +1,9 @@
 # samples
 
-JavaFX 12 samples to run with different options and build tools.
+JavaFX 13 samples to run with different options and build tools.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 Download [JavaFX SDK](https://gluonhq.com/products/javafx/) for your operating 
 system and unzip to a desired location.
@@ -20,8 +20,8 @@ system and unzip to a desired location.
 If you run on Linux or Mac, follow these steps:
 
     cd CommandLine/Modular/CLI/hellofx
-    export PATH_TO_FX=path/to/javafx-sdk-12/lib
-    export PATH_TO_FX_MODS=path/to/javafx-jmods-12
+    export PATH_TO_FX=path/to/javafx-sdk-13/lib
+    export PATH_TO_FX_MODS=path/to/javafx-jmods-13
     javac --module-path $PATH_TO_FX -d mods/hellofx $(find src -name "*.java")
     
 To run the project:
@@ -38,8 +38,8 @@ To create and run a custom JRE:
 If you run on Windows, follow these steps:
 
     cd CommandLine\Modular\CLI\hellofx
-    set PATH_TO_FX="path\to\javafx-sdk-12\lib"
-    set PATH_TO_FX_MODS="path\to\javafx-jmods-12"
+    set PATH_TO_FX="path\to\javafx-sdk-13\lib"
+    set PATH_TO_FX_MODS="path\to\javafx-jmods-13"
     dir /s /b src\*.java > sources.txt & javac --module-path %PATH_TO_FX% -d mods/hellofx @sources.txt & del sources.txt
 
 To run the project:

--- a/CommandLine/Modular/Gradle/README.md
+++ b/CommandLine/Modular/Gradle/README.md
@@ -1,9 +1,9 @@
 # samples
 
-JavaFX 12 samples to run with different options and build tools.
+JavaFX 13 samples to run with different options and build tools.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 ## Modular - Gradle
 

--- a/CommandLine/Modular/Gradle/hellofx/build.gradle
+++ b/CommandLine/Modular/Gradle/hellofx/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 javafx {
-    version = "12.0.2"
+    version = "13"
     modules = [ 'javafx.controls' ]
 }
 

--- a/CommandLine/Modular/Maven/README.md
+++ b/CommandLine/Modular/Maven/README.md
@@ -1,9 +1,9 @@
 # samples
 
-JavaFX 12 samples to run with different options and build tools.
+JavaFX 13 samples to run with different options and build tools.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 ## Modular - Maven
 

--- a/CommandLine/Modular/Maven/hellofx/pom.xml
+++ b/CommandLine/Modular/Maven/hellofx/pom.xml
@@ -11,6 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>11</maven.compiler.release>
+        <javafx.version>13</javafx.version>
     </properties>
 
     <organization>
@@ -22,12 +24,12 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -37,7 +39,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>12</release>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -45,7 +47,7 @@
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.3</version>
                 <configuration>
-                    <release>12</release>
+                    <release>${maven.compiler.release}</release>
                     <jlinkImageName>hellofx</jlinkImageName>
                     <launcher>launcher</launcher>
                     <mainClass>hellofx/org.openjfx.MainApp</mainClass>

--- a/CommandLine/Non-modular/CLI/README.md
+++ b/CommandLine/Non-modular/CLI/README.md
@@ -1,9 +1,9 @@
 # samples
 
-JavaFX 12 samples to run with different options and build tools.
+JavaFX 13 samples to run with different options and build tools.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 Download [JavaFX SDK](https://gluonhq.com/products/javafx/) for your operating 
 system and unzip to a desired location.
@@ -17,7 +17,7 @@ system and unzip to a desired location.
 If you run on Linux or Mac, follow these steps:
 
     cd CommandLine/Non-modular/CLI/hellofx
-    export PATH_TO_FX=path/to/javafx-sdk-12/lib
+    export PATH_TO_FX=path/to/javafx-sdk-13/lib
     javac --module-path $PATH_TO_FX --add-modules=javafx.controls -d out $(find src -name "*.java")
     
 To run the project:
@@ -45,7 +45,7 @@ To create a fat jar:
 If you run on Windows, follow these steps:
 
     cd CommandLine\Non-modular\CLI\hellofx
-    set PATH_TO_FX="path\to\javafx-sdk-12\lib"
+    set PATH_TO_FX="path\to\javafx-sdk-13\lib"
     dir /s /b src\*.java > sources.txt & javac --module-path %PATH_TO_FX% --add-modules=javafx.controls -d out @sources.txt & del sources.txt
 
 To run the project:

--- a/CommandLine/Non-modular/Gradle/README.md
+++ b/CommandLine/Non-modular/Gradle/README.md
@@ -1,9 +1,9 @@
 # samples
 
-JavaFX 12 samples to run with different options and build tools.
+JavaFX 13 samples to run with different options and build tools.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 ## Non-modular - Gradle
 

--- a/CommandLine/Non-modular/Gradle/hellofx/build.gradle
+++ b/CommandLine/Non-modular/Gradle/hellofx/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 }
 
 javafx {
-    version = "12.0.2"
+    version = "13"
     modules = [ 'javafx.controls' ]
 }
 

--- a/CommandLine/Non-modular/Maven/README.md
+++ b/CommandLine/Non-modular/Maven/README.md
@@ -1,9 +1,9 @@
 # samples
 
-JavaFX 12 samples to run with different options and build tools.
+JavaFX 13 samples to run with different options and build tools.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 ## Non-modular - Maven
 

--- a/CommandLine/Non-modular/Maven/hellofx/pom.xml
+++ b/CommandLine/Non-modular/Maven/hellofx/pom.xml
@@ -9,6 +9,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>11</maven.compiler.release>
+        <javafx.version>13</javafx.version>
     </properties>
 
   <name>hellofx</name>
@@ -17,27 +19,29 @@
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-controls</artifactId>
-      <version>12.0.2</version>
+      <version>${javafx.version}</version>
     </dependency>
-    <!-- Uncomment for cross-platform fat jar
-    <dependency>
+    <!-- Uncomment for cross-platform fat jar-->
+    <!--
+      <dependency>
         <groupId>org.openjfx</groupId>
         <artifactId>javafx-graphics</artifactId>
-        <version>12.0.2</version>
+        <version>${javafx.version}</version>
         <classifier>win</classifier>
     </dependency>
     <dependency>
         <groupId>org.openjfx</groupId>
         <artifactId>javafx-graphics</artifactId>
-        <version>12.0.2</version>
+        <version>${javafx.version}</version>
         <classifier>linux</classifier>
     </dependency>
     <dependency>
         <groupId>org.openjfx</groupId>
         <artifactId>javafx-graphics</artifactId>
-        <version>12.0.2</version>
+        <version>${javafx.version}</version>
         <classifier>mac</classifier>
-    </dependency> -->
+    </dependency>
+    -->
   </dependencies>
   
   <build>
@@ -47,7 +51,7 @@
               <artifactId>maven-compiler-plugin</artifactId>
               <version>3.8.1</version>
               <configuration>
-                  <release>12</release>
+                  <release>${maven.compiler.release}</release>
               </configuration>
           </plugin>
           <plugin>

--- a/HelloFX/CLI/README.md
+++ b/HelloFX/CLI/README.md
@@ -1,9 +1,9 @@
 # HelloFX Sample
 
-JavaFX 12 HelloFX sample to run with different options and build tools.
+JavaFX 13 HelloFX sample to run with different options and build tools.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 ## CLI
 
@@ -15,7 +15,7 @@ system and unzip to a desired location.
 If you run on Linux or Mac, follow these steps:
 
     cd HelloFX/CLI/hellofx
-    export PATH_TO_FX=path/to/javafx-sdk-12/lib
+    export PATH_TO_FX=path/to/javafx-sdk-13/lib
 
 Compile:
 
@@ -30,7 +30,7 @@ Run:
 If you run on Windows, follow these steps:
 
     cd HelloFX\CLI\hellofx
-    set PATH_TO_FX="path\to\javafx-sdk-12\lib"
+    set PATH_TO_FX="path\to\javafx-sdk-13\lib"
 
 Compile:
 

--- a/HelloFX/Gradle/README.md
+++ b/HelloFX/Gradle/README.md
@@ -1,9 +1,9 @@
 # HelloFX Sample
 
-JavaFX 12 HelloFX sample to run with different options and build tools.
+JavaFX 13 HelloFX sample to run with different options and build tools.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 ## Gradle
 

--- a/HelloFX/Gradle/hellofx/build.gradle
+++ b/HelloFX/Gradle/hellofx/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 javafx {
-    version = "12.0.2"
+    version = "13"
     modules = [ 'javafx.controls' ]
 }
 

--- a/HelloFX/Maven/README.md
+++ b/HelloFX/Maven/README.md
@@ -1,9 +1,9 @@
 # HelloFX Sample
 
-JavaFX 12 HelloFX sample to run with different options and build tools.
+JavaFX 13 HelloFX sample to run with different options and build tools.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 ## Maven
 

--- a/HelloFX/Maven/hellofx/pom.xml
+++ b/HelloFX/Maven/hellofx/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-controls</artifactId>
-      <version>12.0.2</version>
+      <version>13</version>
     </dependency>
   </dependencies>
   <build>

--- a/IDE/Eclipse/Modular/Gradle/README.md
+++ b/IDE/Eclipse/Modular/Gradle/README.md
@@ -1,13 +1,13 @@
 ## Modular samples for Eclipse
 
-JavaFX 12 samples to run from Eclipse with different options and build tools
+JavaFX 13 samples to run from Eclipse with different options and build tools
 
 Version Eclipse: 2019-03 (4.11.0)
 
-Install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+**N.B**: If you use JDK 12, install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
 
 ### Gradle
 
@@ -15,7 +15,7 @@ For the first time only:
 
 - Make sure you have the Buildship Gradle Integration 3.0 plugin installed.
 
-- Add `org.gradle.java.home` to a `gradle.properties` file, with the path to JDK 12. This file 
+- Add `org.gradle.java.home` to a `gradle.properties` file, with the path to JDK. This file 
 can be part of the project or under the gradle user home `USER_HOME/.gradle`. 
 
 Clone the sample, open it with Eclipse and refresh the Gradle project. 

--- a/IDE/Eclipse/Modular/Gradle/hellofx/build.gradle
+++ b/IDE/Eclipse/Modular/Gradle/hellofx/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 javafx {
-    version = "12.0.2"
+    version = "13"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/IDE/Eclipse/Modular/Gradle/hellofx/gradle.properties
+++ b/IDE/Eclipse/Modular/Gradle/hellofx/gradle.properties
@@ -1,4 +1,4 @@
-## if JAVA_HOME is not JDK 12, set and uncomment:
-#org.gradle.java.home=/path/to/jdk-12/
+## if JAVA_HOME is not JDK, set and uncomment:
+#org.gradle.java.home=/path/to/jdk/
 
 

--- a/IDE/Eclipse/Modular/Java/HelloFX/src/org/openjfx/MainApp.java
+++ b/IDE/Eclipse/Modular/Java/HelloFX/src/org/openjfx/MainApp.java
@@ -16,7 +16,7 @@ public class MainApp extends Application {
         Scene scene = new Scene(root);
         scene.getStylesheets().add(getClass().getResource("styles.css").toExternalForm());
 
-        stage.setTitle("JavaFX 12");
+        stage.setTitle("JavaFX 13");
         stage.setScene(scene);
         stage.show();
     }

--- a/IDE/Eclipse/Modular/Java/README.md
+++ b/IDE/Eclipse/Modular/Java/README.md
@@ -1,13 +1,13 @@
 ## Modular samples for Eclipse
 
-JavaFX 12 samples to run from Eclipse with different options and build tools
+JavaFX 13 samples to run from Eclipse with different options and build tools
 
 Version Eclipse: 2019-03 (4.11.0)
 
-Install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+**N.B**: If you use JDK 12, install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
 
 ### Java
 
@@ -23,13 +23,13 @@ To create and run a custom JRE, from terminal:
 On Linux or Mac run:
 
     cd IDE/Eclipse/Modular/Java/HelloFX
-    export PATH_TO_FX_MODS=path/to/javafx-jmods-12
+    export PATH_TO_FX_MODS=path/to/javafx-jmods-13
     $JAVA_HOME/bin/jlink --module-path $PATH_TO_FX_MODS:bin/hellofx --add-modules=hellofx --output jre
     jre/bin/java -m hellofx/org.openjfx.MainApp
 
 On Windows run:
 
     cd IDE\Eclipse\Modular\Java\HelloFX
-    set PATH_TO_FX_MODS="path\to\javafx-jmods-12"
+    set PATH_TO_FX_MODS="path\to\javafx-jmods-13"
     jlink --module-path "%PATH_TO_FX_MODS%;bin\hellofx" --add-modules=hellofx --output jre
     jre\bin\java -m hellofx/org.openjfx.MainApp

--- a/IDE/Eclipse/Modular/Maven/README.md
+++ b/IDE/Eclipse/Modular/Maven/README.md
@@ -1,13 +1,13 @@
 ## Modular samples for Eclipse
 
-JavaFX 12 samples to run from Eclipse with different options and build tools
+JavaFX 13 samples to run from Eclipse with different options and build tools
 
 Version Eclipse: 2019-03 (4.11.0)
 
-Install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+**N.B**: If you use JDK 12, install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
 
 ### Maven
 
@@ -17,8 +17,8 @@ For the first time only:
 
 - Add the JavaFX Maven archetypes `org.openjfx:javafx-archetype-simple:0.0.1` and `org.openjfx:javafx-archetype-fxml:0.0.1`
 
-Clone the sample, open it with Eclipse, and make sure the paths for Java 12 and 
-JavaFX 12 match those on your machine.
+Clone the sample, open it with Eclipse, and make sure the paths for JDK and 
+JavaFX match those on your machine.
 
 Run with `Run configurations -> Maven Build -> hellofx`.
 
@@ -30,7 +30,7 @@ Note: on Windows, under Eclipse running Oracle JDK 1.8, you need to add `-Djava.
 to the JavaFX maven plugin:
 
     <configuration>
-        <executable>/path/to/Java/12/bin/java</executable>
+        <executable>/path/to/JDK/bin/java</executable>
         <options>
             <option>-Djava.library.path=C:\tmp</option>
         </options>

--- a/IDE/Eclipse/Modular/Maven/hellofx/pom.xml
+++ b/IDE/Eclipse/Modular/Maven/hellofx/pom.xml
@@ -6,19 +6,19 @@
     <version>0.0.1-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>12</maven.compiler.source>
-        <maven.compiler.target>12</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <javafx.version>13</javafx.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -28,7 +28,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>12</release>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -36,7 +36,7 @@
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.3</version>
                 <configuration>
-                    <release>12</release>
+                    <release>${maven.compiler.release}</release>
                     <jlinkImageName>hellofx</jlinkImageName>
                     <launcher>launcher</launcher>
                     <mainClass>hellofx/org.openjfx.hellofx.App</mainClass>

--- a/IDE/Eclipse/Non-Modular/Gradle/README.md
+++ b/IDE/Eclipse/Non-Modular/Gradle/README.md
@@ -1,19 +1,19 @@
 ## Non-modular samples for Eclipse
 
-JavaFX 12 samples to run from Eclipse with different options and build tools
+JavaFX 13 samples to run from Eclipse with different options and build tools
 
 Version Eclipse: 2019-03 (4.11.0)
 
-Install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+**N.B**: If you use JDK 12, install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
 
 ### Gradle
 
 Clone the sample, add a `gradle.properties` file with this property:
 
-    org.gradle.java.home=/path/to/Java/12
+    org.gradle.java.home=/path/to/JDK
 
 Open it with Eclipse and refresh the Gradle project. 
 

--- a/IDE/Eclipse/Non-Modular/Gradle/hellofx/build.gradle
+++ b/IDE/Eclipse/Non-Modular/Gradle/hellofx/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 javafx {
-    version = "12.0.2"
+    version = "13"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/IDE/Eclipse/Non-Modular/Java/README.md
+++ b/IDE/Eclipse/Non-Modular/Java/README.md
@@ -1,13 +1,13 @@
 ## Non-modular samples for Eclipse
 
-JavaFX 12 samples to run from Eclipse with different options and build tools
+JavaFX 13 samples to run from Eclipse with different options and build tools
 
 Version Eclipse: 2019-03 (4.11.0)
 
-Install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+**N.B**: If you use JDK 12, install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
 
 ### Java
 
@@ -17,13 +17,12 @@ For the first time only:
 system and unzip to a desired location.
 
 - Open Eclipse and create a string substitution variable under `Preferences->Run/Debug->String Substitution`, named `PATH_TO_FX` and
-pointing to the JavaFX 12 lib folder. 
+pointing to the JavaFX 13 lib folder. 
 
 - Create a User Library under `Eclipse -> Window -> Preferences -> Java -> Build Path -> User Libraries -> New`.
-Name it `JavaFX12` and include the jars under the lib folder from JavaFX 12.
+Name it `JavaFX13` and include the jars under the lib folder from JavaFX 13.
 
-Clone the sample, open it with Eclipse, and make sure the paths for Java 12 and 
-JavaFX 12 match those on your machine.
+Clone the sample, open it with Eclipse, and make sure the paths for JDK and JavaFX match those on your machine.
 
 Build the project and run with Run configurations-> Java Application -> HelloFX.
 

--- a/IDE/Eclipse/Non-Modular/Java/hellofx/.classpath
+++ b/IDE/Eclipse/Non-Modular/Java/hellofx/.classpath
@@ -6,6 +6,6 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JavaFX12"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JavaFX13"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/IDE/Eclipse/Non-Modular/Maven/README.md
+++ b/IDE/Eclipse/Non-Modular/Maven/README.md
@@ -1,13 +1,13 @@
 ## Non-modular samples for Eclipse
 
-JavaFX 12 samples to run from Eclipse with different options and build tools
+JavaFX 13 samples to run from Eclipse with different options and build tools
 
 Version Eclipse: 2019-03 (4.11.0)
 
-Install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory.
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+**N.B**: If you use JDK 12, install this patch from MarketPlace: `Java 12 support for Eclipse 2019-03 (4.11)`.
 
 ### Maven
 
@@ -25,7 +25,7 @@ Note: on Windows, under Eclipse running Oracle JDK 1.8, you need to add `-Djava.
 to the JavaFX maven plugin:
 
     <configuration>
-        <executable>/path/to/Java/12/bin/java</executable>
+        <executable>/path/to/JDK/bin/java</executable>
         <options>
             <option>-Djava.library.path=C:\tmp</option>
         </options>

--- a/IDE/Eclipse/Non-Modular/Maven/hellofx/pom.xml
+++ b/IDE/Eclipse/Non-Modular/Maven/hellofx/pom.xml
@@ -6,19 +6,19 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>12</maven.compiler.source>
-        <maven.compiler.target>12</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <javafx.version>13</javafx.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -28,7 +28,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>12</release>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/IDE/IntelliJ/Modular/Gradle/README.md
+++ b/IDE/IntelliJ/Modular/Gradle/README.md
@@ -1,11 +1,11 @@
 ## Modular samples for IntelliJ
 
-JavaFX 12 samples to run from IntelliJ with different options and build tools
+JavaFX 13 samples to run from IntelliJ with different options and build tools
 
 Version IntelliJ IDEA 20189.1
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 Download [JavaFX jmods](https://gluonhq.com/products/javafx/) for your operating 
 system and unzip to a desired location.

--- a/IDE/IntelliJ/Modular/Gradle/hellofx/build.gradle
+++ b/IDE/IntelliJ/Modular/Gradle/hellofx/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 javafx {
-    version = "12.0.2"
+    version = "13"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/IDE/IntelliJ/Modular/Java/README.md
+++ b/IDE/IntelliJ/Modular/Java/README.md
@@ -1,11 +1,11 @@
 ## Modular samples for IntelliJ
 
-JavaFX 12 samples to run from IntelliJ with different options and build tools
+JavaFX 13 samples to run from IntelliJ with different options and build tools
 
 Version IntelliJ IDEA 2019.1
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 Download [JavaFX jmods](https://gluonhq.com/products/javafx/) for your operating 
 system and unzip to a desired location.
@@ -15,11 +15,10 @@ system and unzip to a desired location.
 Download [JavaFX SDK](https://gluonhq.com/products/javafx/) for your operating 
 system and unzip to a desired location.
 
-Clone the sample, open it with IntelliJ, and make sure the paths for Java 12 and 
-JavaFX 12 match those on your machine.
+Clone the sample, open it with IntelliJ, and make sure the paths for JDK and JavaFX match those on your machine.
 
 Define the following Path Variables in Preferences/Settings: 
- - name `PATH_TO_FX`, value `path/to/javafx-sdk-12/lib`
+ - name `PATH_TO_FX`, value `path/to/javafx-sdk-13/lib`
  - name `PATH_SEPARATOR`, value `:` on Linux/Mac, `;` on Windows.
 
 Run the `runHelloFX` configuration.
@@ -29,13 +28,13 @@ To create and run a custom JRE, from terminal:
 On Linux or Mac run:
 
     cd IDE/IntelliJ/Modular/Java/hellofx
-    export PATH_TO_FX_MODS=path/to/javafx-jmods-12
+    export PATH_TO_FX_MODS=path/to/javafx-jmods-13
     $JAVA_HOME/bin/jlink --module-path $PATH_TO_FX_MODS:mods/production --add-modules hellofx --output jre
     jre/bin/java -m hellofx/org.openjfx.MainApp
 
 On Windows run:
 
     cd IDE\IntelliJ\Modular\Java\hellofx
-    set PATH_TO_FX_MODS="path\to\javafx-jmods-12"
+    set PATH_TO_FX_MODS="path\to\javafx-jmods-13"
     jlink --module-path "%PATH_TO_FX_MODS%;mods\production" --add-modules hellofx --output jre
     jre\bin\java -m hellofx/org.openjfx.MainApp

--- a/IDE/IntelliJ/Modular/Java/hellofx/src/org/openjfx/MainApp.java
+++ b/IDE/IntelliJ/Modular/Java/hellofx/src/org/openjfx/MainApp.java
@@ -16,7 +16,7 @@ public class MainApp extends Application {
         Scene scene = new Scene(root);
         scene.getStylesheets().add(getClass().getResource("styles.css").toExternalForm());
 
-        stage.setTitle("JavaFX 12");
+        stage.setTitle("JavaFX 13");
         stage.setScene(scene);
         stage.show();
     }

--- a/IDE/IntelliJ/Modular/Maven/README.md
+++ b/IDE/IntelliJ/Modular/Maven/README.md
@@ -1,16 +1,15 @@
 ## Modular samples for IntelliJ
 
-JavaFX 12 samples to run from IntelliJ with different options and build tools
+JavaFX 13 samples to run from IntelliJ with different options and build tools
 
 Version IntelliJ IDEA 2019.1
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 ### Maven
 
-Clone the sample, open it with IntelliJ, and make sure the paths for Java 12 and 
-JavaFX 12 match those on your machine.
+Clone the sample, open it with IntelliJ, and make sure the paths for JDK and JavaFX match those on your machine.
 
 Run from command line:
 

--- a/IDE/IntelliJ/Modular/Maven/hellofx/pom.xml
+++ b/IDE/IntelliJ/Modular/Maven/hellofx/pom.xml
@@ -6,19 +6,19 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>12</maven.compiler.source>
-        <maven.compiler.target>12</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <javafx.version>13</javafx.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -28,7 +28,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>12</release>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -36,7 +36,7 @@
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.3</version>
                 <configuration>
-                    <release>12</release>
+                    <release>${maven.compiler.release}</release>
                     <jlinkImageName>hellofx</jlinkImageName>
                     <launcher>launcher</launcher>
                     <mainClass>hellofx/org.openjfx.App</mainClass>

--- a/IDE/IntelliJ/Non-Modular/Gradle/README.md
+++ b/IDE/IntelliJ/Non-Modular/Gradle/README.md
@@ -1,11 +1,11 @@
 ## Non-modular samples for IntelliJ
 
-JavaFX 12 samples to run from IntelliJ with different options and build tools
+JavaFX 13 samples to run from IntelliJ with different options and build tools
 
 Version IntelliJ IDEA 2019.1
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 ### Gradle
 

--- a/IDE/IntelliJ/Non-Modular/Gradle/hellofx/build.gradle
+++ b/IDE/IntelliJ/Non-Modular/Gradle/hellofx/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 javafx {
-    version = "12.0.2"
+    version = "13"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/IDE/IntelliJ/Non-Modular/Java/README.md
+++ b/IDE/IntelliJ/Non-Modular/Java/README.md
@@ -1,18 +1,17 @@
 ## Non-modular samples for IntelliJ
 
-JavaFX 12 samples to run from IntelliJ with different options and build tools
+JavaFX 13 samples to run from IntelliJ with different options and build tools
 
 Version IntelliJ IDEA 2019.1
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 ### Java
 
 Download [JavaFX SDK](https://gluonhq.com/products/javafx/) for your operating 
 system and unzip to a desired location.
 
-Clone the sample, open it with IntelliJ, and make sure the paths for Java 12 and 
-JavaFX 12 match those on your machine.
+Clone the sample, open it with IntelliJ, and make sure the paths for JDK and JavaFX match those on your machine.
 
 Run with `Run -> Edit configurations -> Main`.

--- a/IDE/IntelliJ/Non-Modular/Maven/README.md
+++ b/IDE/IntelliJ/Non-Modular/Maven/README.md
@@ -1,11 +1,11 @@
 ## Non-modular samples for IntelliJ
 
-JavaFX 12 samples to run from IntelliJ with different options and build tools
+JavaFX 13 samples to run from IntelliJ with different options and build tools
 
 Version IntelliJ IDEA 2019.1
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 ### Maven
 

--- a/IDE/IntelliJ/Non-Modular/Maven/hellofx/pom.xml
+++ b/IDE/IntelliJ/Non-Modular/Maven/hellofx/pom.xml
@@ -6,19 +6,19 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>12</maven.compiler.source>
-        <maven.compiler.target>12</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <javafx.version>13</javafx.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -28,7 +28,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>12</release>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/IDE/NetBeans/Modular/Gradle/README.md
+++ b/IDE/NetBeans/Modular/Gradle/README.md
@@ -1,11 +1,11 @@
 ## Modular samples for NetBeans
 
-JavaFX 12 samples to run from NetBeans with different options and build tools
+JavaFX 13 samples to run from NetBeans with different options and build tools
 
 Version NetBeans [11.1](https://netbeans.apache.org/download/nb111/nb111.html)
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 The samples assume NetBeans 10 runs on JDK 12 (this can be set editing the `etc/netbeans.conf` file
 and setting `netbeans_jdkhome="/path/to/jdk12"`).

--- a/IDE/NetBeans/Modular/Gradle/hellofx/build.gradle
+++ b/IDE/NetBeans/Modular/Gradle/hellofx/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 javafx {
-    version = "12.0.2"
+    version = "13"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/IDE/NetBeans/Modular/Java/HelloFX/nbproject/project.properties
+++ b/IDE/NetBeans/Modular/Java/HelloFX/nbproject/project.properties
@@ -44,7 +44,7 @@ javac.compilerargs=
 javac.deprecation=false
 javac.external.vm=false
 javac.modulepath=\
-    ${libs.JavaFX12.classpath}
+    ${libs.JavaFX13.classpath}
 javac.processormodulepath=
 javac.processorpath=\
     ${javac.classpath}
@@ -83,7 +83,7 @@ run.classpath=
 # To set system properties for unit tests define test-sys-prop.name=value:
 run.jvmargs=
 run.modulepath=\
-    ${libs.JavaFXMODS12.classpath}:\
+    ${libs.JavaFXMODS13.classpath}:\
     ${javac.modulepath}:\
     ${build.modules.dir}
 run.test.classpath=\

--- a/IDE/NetBeans/Modular/Java/HelloFX/src/hellofx/classes/org/openjfx/MainApp.java
+++ b/IDE/NetBeans/Modular/Java/HelloFX/src/hellofx/classes/org/openjfx/MainApp.java
@@ -16,7 +16,7 @@ public class MainApp extends Application {
         Scene scene = new Scene(root);
         scene.getStylesheets().add(getClass().getResource("styles.css").toExternalForm());
 
-        stage.setTitle("JavaFX 12");
+        stage.setTitle("JavaFX 13");
         stage.setScene(scene);
         stage.show();
     }

--- a/IDE/NetBeans/Modular/Java/README.md
+++ b/IDE/NetBeans/Modular/Java/README.md
@@ -1,11 +1,11 @@
 ## Modular samples for NetBeans
 
-JavaFX 12 samples to run from NetBeans with different options and build tools
+JavaFX 13 samples to run from NetBeans with different options and build tools
 
 Version NetBeans [11.1](https://netbeans.apache.org/download/nb111/nb111.html)
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 The samples assume NetBeans 11 runs on JDK 12 (this can be set editing the `etc/netbeans.conf` file
 and setting `netbeans_jdkhome="/path/to/jdk12"`).
@@ -21,13 +21,12 @@ For the first time only:
 system and unzip to a desired location.
 
 - Open NetBeans and create a global Library under `NetBeans -> Tools -> Libraries -> New Library`.
-Name it `JavaFX12` and include the jars under the lib folder from JavaFX 12 (but not the `src.zip` file).
+Name it `JavaFX13` and include the jars under the lib folder from JavaFX 13 (but not the `src.zip` file).
 
 - Create a global Library under `NetBeans -> Tools -> Libraries -> New Library`.
-Name it `JavaFXMODS12` and include the folder JavaFX jmods 12.
+Name it `JavaFXMODS13` and include the folder JavaFX jmods 13.
 
-Clone the sample, open it with NetBeans, and make sure the paths for Java 12 and 
-JavaFX 12 match those on your machine.
+Clone the sample, open it with NetBeans, and make sure the paths for JDK and JavaFX match those on your machine.
 
 Clean and build with regular button to create a custom JRE.
 Run with regular button.

--- a/IDE/NetBeans/Modular/Maven/README.md
+++ b/IDE/NetBeans/Modular/Maven/README.md
@@ -1,11 +1,11 @@
 ## Modular samples for NetBeans
 
-JavaFX 12 samples to run from NetBeans with different options and build tools
+JavaFX 13 samples to run from NetBeans with different options and build tools
 
 Version NetBeans [11.1](https://netbeans.apache.org/download/nb111/nb111.html)
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 The samples assume NetBeans 11 runs on JDK 12 (this can be set editing the `etc/netbeans.conf` file
 and setting `netbeans_jdkhome="/path/to/jdk12"`).
@@ -15,8 +15,7 @@ system and unzip to a desired location.
 
 ### Maven
 
-Clone the sample, open it with NetBeans, and make sure the paths for Java 12 and 
-JavaFX 12 match those on your machine.
+Clone the sample, open it with NetBeans, and make sure the paths for JDK and JavaFX match those on your machine.
 
 Clean, build and run from the NetBeans usual buttons, or from command line:
 

--- a/IDE/NetBeans/Modular/Maven/hellofx/pom.xml
+++ b/IDE/NetBeans/Modular/Maven/hellofx/pom.xml
@@ -6,19 +6,19 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>12</maven.compiler.source>
-        <maven.compiler.target>12</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <javafx.version>13</javafx.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -28,7 +28,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>12</release>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -36,7 +36,7 @@
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.3</version>
                 <configuration>
-                    <release>12</release>
+                    <release>${maven.compiler.release}</release>
                     <jlinkImageName>hellofx</jlinkImageName>
                     <launcher>launcher</launcher>
                     <mainClass>hellofx/org.openjfx.hellofx.App</mainClass>

--- a/IDE/NetBeans/Non-Modular/Gradle/README.md
+++ b/IDE/NetBeans/Non-Modular/Gradle/README.md
@@ -1,11 +1,11 @@
 ## Non-modular samples for NetBeans
 
-JavaFX 12 samples to run from NetBeans with different options and build tools
+JavaFX 13 samples to run from NetBeans with different options and build tools
 
 Version NetBeans [11.1](https://netbeans.apache.org/download/nb111/nb111.html)
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 The samples assume NetBeans 11 runs on JDK 12 (this can be set editing the `etc/netbeans.conf` file
 and setting `netbeans_jdkhome="/path/to/jdk12"`).

--- a/IDE/NetBeans/Non-Modular/Gradle/hellofx/build.gradle
+++ b/IDE/NetBeans/Non-Modular/Gradle/hellofx/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 javafx {
-    version = "12.0.2"
+    version = "13"
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 

--- a/IDE/NetBeans/Non-Modular/Java/README.md
+++ b/IDE/NetBeans/Non-Modular/Java/README.md
@@ -1,11 +1,11 @@
 ## Non-modular samples for NetBeans
 
-JavaFX 12 samples to run from NetBeans with different options and build tools
+JavaFX 13 samples to run from NetBeans with different options and build tools
 
 Version NetBeans [11.1](https://netbeans.apache.org/download/nb111/nb111.html)
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 The samples assume NetBeans 11 runs on JDK 12 (this can be set editing the `etc/netbeans.conf` file
 and setting `netbeans_jdkhome="/path/to/jdk12"`).
@@ -18,7 +18,6 @@ For the first time only:
 system and unzip to a desired location.
 
 - Open NetBeans and create a global Library under `NetBeans -> Tools -> Libraries -> New Library`.
-Name it `JavaFX12` and include the jars under the lib folder from JavaFX 12 (but not the `src.zip` file).
+Name it `JavaFX13` and include the jars under the lib folder from JavaFX 13 (but not the `src.zip` file).
 
-Clone the sample, open it with NetBeans, and make sure the paths for Java 12 and 
-JavaFX 12 match those on your machine.
+Clone the sample, open it with NetBeans, and make sure the paths for JDK and JavaFX match those on your machine.

--- a/IDE/NetBeans/Non-Modular/Java/hellofx/nbproject/project.properties
+++ b/IDE/NetBeans/Non-Modular/Java/hellofx/nbproject/project.properties
@@ -38,7 +38,7 @@ excludes=
 includes=**
 jar.compress=false
 javac.classpath=\
-    ${libs.JAVAFX12.classpath}
+    ${libs.JAVAFX13.classpath}
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
@@ -88,7 +88,7 @@ run.classpath=\
 run.jvmargs=--add-modules javafx.controls,javafx.fxml
 run.modulepath=\
     ${javac.modulepath}:\
-    ${libs.JAVAFX12.classpath}
+    ${libs.JAVAFX13.classpath}
 run.test.classpath=\
     ${javac.test.classpath}:\
     ${build.test.classes.dir}

--- a/IDE/NetBeans/Non-Modular/Maven/README.md
+++ b/IDE/NetBeans/Non-Modular/Maven/README.md
@@ -1,11 +1,11 @@
 ## Non-modular samples for NetBeans
 
-JavaFX 12 samples to run from NetBeans with different options and build tools
+JavaFX 13 samples to run from NetBeans with different options and build tools
 
 Version NetBeans [11.1](https://netbeans.apache.org/download/nb111/nb111.html)
 
-Download an appropriate [JDK 12](https://jdk.java.net/12/) for your operating system. Make sure `JAVA_HOME` 
-is properly set to the Java 12 installation directory. 
+Download [JDK 11 or later](http://jdk.java.net/) for your operating system.
+Make sure `JAVA_HOME` is properly set to the JDK installation directory. 
 
 The samples assume NetBeans 11 runs on JDK 12 (this can be set editing the `etc/netbeans.conf` file
 and setting `netbeans_jdkhome="/path/to/jdk12"`).

--- a/IDE/NetBeans/Non-Modular/Maven/hellofx/pom.xml
+++ b/IDE/NetBeans/Non-Modular/Maven/hellofx/pom.xml
@@ -6,19 +6,19 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>12</maven.compiler.source>
-        <maven.compiler.target>12</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <javafx.version>13</javafx.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>12.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -28,7 +28,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>12</release>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Description
 ---
 
 This repository contains a collection of HelloFX samples. Each one is a very simple 
-HelloWorld sample created with JavaFX 12 that can be run with different options and build tools.
+HelloWorld sample created with JavaFX 13 that can be run with different options and build tools.
 
 The related documentation for each sample can be found [here](https://openjfx.io/openjfx-docs/).
 


### PR DESCRIPTION
Update samples and documents to JavaFX 13.

I have also tried to remove data which needs to be updated every time. For example, we explicitly mention "JDK 12" in our documents to be used with JavaFX 12. This has been replaced by "JDK 11 or later".