### PR TITLE
fails with user testing

### DIFF
--- a/IDE/IntelliJ/Modular/Maven/README.md
+++ b/IDE/IntelliJ/Modular/Maven/README.md
@@ -13,15 +13,17 @@ Clone the sample, open it with IntelliJ, and make sure the paths for JDK and Jav
 
 Run from command line:
 
+    cd samples/IDE/IntelliJ/Modular/Maven/hellofx
     mvn clean javafx:run
+    cd ..
 
 As well, this will work from the terminal on Linux or Mac:
 
-    java --module-path $PATH_TO_FX:target/hellofx-1.0-SNAPSHOT.jar -m hellofx/org.openjfx.MainApp
+    java --module-path $PATH_TO_FX:target/hellofx-1.0-SNAPSHOT.jar -m hellofx/org.openjfx.App
 
 or on Windows:
     
-    java --module-path %PATH_TO_FX%:target\hellofx-1.0-SNAPSHOT.jar -m hellofx/org.openjfx.MainApp
+    java --module-path %PATH_TO_FX%:target\hellofx-1.0-SNAPSHOT.jar -m hellofx/org.openjfx.App
 
 To create and run a custom JRE, from terminal:
 


### PR DESCRIPTION
Needed a `cd`.
There is no `MainApp`, only an `App`.
More explanation here would be helpful. And please user-test.
Should explain why the `--module-path` is needed when using maven. Maven doesn't put openJfx all in one dir somewhere but makes a forest of versioned dirs, so where would this PATH_TO_FX be? Are we supposed to download openjfx in addition to relying on maven to download it? Confusing.