### PR TITLE
Fix Maven compilation error

### DIFF
--- a/HelloFX/Maven/hellofx/pom.xml
+++ b/HelloFX/Maven/hellofx/pom.xml
@@ -12,6 +12,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javafx.version>21</javafx.version>
     <javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This fixes the following Maven compilation error:

    [ERROR] COMPILATION ERROR :
    [INFO] -------------------------------------------------------------
    [ERROR] Source option 5 is no longer supported. Use 8 or later.
    [ERROR] Target option 5 is no longer supported. Use 8 or later.
    [INFO] 2 errors

Relevant StackOverflow thread: https://stackoverflow.com/a/58195741/